### PR TITLE
Leeds case study

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     httr,
     jsonlite,
     sf,
-    readr
+    readr,
+    janitor
 RoxygenNote: 7.0.2
 Suggests: 
     covr,

--- a/R/accessibility.R
+++ b/R/accessibility.R
@@ -37,7 +37,7 @@ get_jts_data = function(table, year = NULL, u_csv = NULL, skip = 6) {
   }
 
   message("Reading in file ", u_csv)
-  res = readr::read_csv(u_csv, skip = skip)
+  res = janitor::remove_empty(readr::read_csv(u_csv, skip = skip),"cols")
   names(res) = gsub(pattern = "100", replacement = "Jobs100", names(res))
   names(res) = gsub(pattern = "500", replacement = "Jobs500", names(res))
   res

--- a/code/allertonbywater.R
+++ b/code/allertonbywater.R
@@ -2,9 +2,9 @@ library(sf)
 library(mapview)
 library(pct)
 library(tidyverse)
+library(acton)
 
 reszone = pct::get_pct_zones(region = "west-yorkshire", geography = "lsoa", purpose = "commute") %>% rename(LA_Code = lad11cd)
-reszone_proj = reszone %>% st_transform(27700)
 
 
 # Allerton Bywater Millennium Community polygon ---------------------------
@@ -105,12 +105,12 @@ sites$place = c("AllertonBywater", "Tyersall", "Micklefield", "LeedsClimateInnov
 #   st_buffer(500) %>%
 #   st_transform(4326)
 
+reszone_proj = reszone %>% st_transform(27700)
 sites = sites %>%
   st_transform(27700)
 sites = st_join(sites,reszone_proj,join = st_within) %>%
   st_transform(4326)
 
-sites$FoodCart
 sites$geo_code
 
 # mapview(abc) +


### PR DESCRIPTION
This includes a simple index of accessibility which combines the stats for access to towns centres, employment, food stores, primary schools, secondary schools and GPs.

Four Leeds sites where planning approval has recently been given for >100 new homes are used as case study sites.

These journey time statistics are measured using LSOA centroids as their point of origin. When assigning value to planning sites, I think in this case it is best to use the value for the closest LSOA centroid, rather than the value for the LSOA in which the site is located. 

Since we are investigating new housing developments, in most cases the LSOA population weighted centroid will not have been placed with respect to the new homes. These homes could be built anywhere within the LSOA, and often new homes are placed far away from existing ones.